### PR TITLE
Add filter and output options to list and list-domain, as well as safety checks destroy.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+. dev/bin/activate

--- a/machine/cloud_config.py
+++ b/machine/cloud_config.py
@@ -20,5 +20,5 @@ runcmd:
   - mkdir -p {machine_config.script_dir}
   - curl -L {machine_config.script_url} -o {machine_config.script_path}
   - chmod +x {machine_config.script_path}
-  - [su, -c, "{machine_config.script_path} {escaped_args}", -, {machine_config.new_user_name}]
+  - [su, -c, "env BPI_MACHINE_SCRIPT_URL='{machine_config.script_url}' BPI_MACHINE_SCRIPT_DIR='{machine_config.script_dir}' {machine_config.script_path} {escaped_args}", -, {machine_config.new_user_name}]
 """

--- a/machine/cloud_config.py
+++ b/machine/cloud_config.py
@@ -20,5 +20,5 @@ runcmd:
   - mkdir -p {machine_config.script_dir}
   - curl -L {machine_config.script_url} -o {machine_config.script_path}
   - chmod +x {machine_config.script_path}
-  - [su, -c, "env BPI_MACHINE_SCRIPT_URL='{machine_config.script_url}' BPI_MACHINE_SCRIPT_DIR='{machine_config.script_dir}' BPI_MACHINE_FQDN='{fqdn}' {machine_config.script_path} {escaped_args}", -, {machine_config.new_user_name}]
+  - [su, -c, "env MACHINE_SCRIPT_URL='{machine_config.script_url}' MACHINE_SCRIPT_DIR='{machine_config.script_dir}' MACHINE_FQDN='{fqdn}' {machine_config.script_path} {escaped_args}", -, {machine_config.new_user_name}]
 """

--- a/machine/cloud_config.py
+++ b/machine/cloud_config.py
@@ -7,6 +7,7 @@ def get_user_data(manager: Manager, ssh_key_name: str, machine_config: MachineCo
 
     ssh_key = sshKeyFromName(manager, ssh_key_name)
     ssh_public_key = ssh_key.public_key
+    escaped_args = machine_config.script_args.replace('"', '\\"')
     return f"""#cloud-config
 users:
   - name: {machine_config.new_user_name}
@@ -19,5 +20,5 @@ runcmd:
   - mkdir -p {machine_config.script_dir}
   - curl -L {machine_config.script_url} -o {machine_config.script_path}
   - chmod +x {machine_config.script_path}
-  - su -c '{machine_config.script_path} {machine_config.script_args}' - {machine_config.new_user_name}
+  - [su, -c, "{machine_config.script_path} {escaped_args}", -, {machine_config.new_user_name}]
 """

--- a/machine/cloud_config.py
+++ b/machine/cloud_config.py
@@ -4,6 +4,8 @@ from machine.util import Manager, sshKeyFromName
 
 
 def get_user_data(manager: Manager, ssh_key_name: str, fqdn: str, machine_config: MachineConfig):
+    if not fqdn:
+        fqdn = ""
 
     ssh_key = sshKeyFromName(manager, ssh_key_name)
     ssh_public_key = ssh_key.public_key

--- a/machine/cloud_config.py
+++ b/machine/cloud_config.py
@@ -3,7 +3,7 @@ from machine.types import MachineConfig
 from machine.util import Manager, sshKeyFromName
 
 
-def get_user_data(manager: Manager, ssh_key_name: str, machine_config: MachineConfig):
+def get_user_data(manager: Manager, ssh_key_name: str, fqdn: str, machine_config: MachineConfig):
 
     ssh_key = sshKeyFromName(manager, ssh_key_name)
     ssh_public_key = ssh_key.public_key
@@ -20,5 +20,5 @@ runcmd:
   - mkdir -p {machine_config.script_dir}
   - curl -L {machine_config.script_url} -o {machine_config.script_path}
   - chmod +x {machine_config.script_path}
-  - [su, -c, "env BPI_MACHINE_SCRIPT_URL='{machine_config.script_url}' BPI_MACHINE_SCRIPT_DIR='{machine_config.script_dir}' {machine_config.script_path} {escaped_args}", -, {machine_config.new_user_name}]
+  - [su, -c, "env BPI_MACHINE_SCRIPT_URL='{machine_config.script_url}' BPI_MACHINE_SCRIPT_DIR='{machine_config.script_dir}' BPI_MACHINE_FQDN='{fqdn}' {machine_config.script_path} {escaped_args}", -, {machine_config.new_user_name}]
 """

--- a/machine/cloud_config.py
+++ b/machine/cloud_config.py
@@ -1,4 +1,3 @@
-
 from machine.types import MachineConfig
 from machine.util import Manager, sshKeyFromName
 
@@ -7,9 +6,13 @@ def get_user_data(manager: Manager, ssh_key_name: str, fqdn: str, machine_config
     if not fqdn:
         fqdn = ""
 
+    script_args = machine_config.script_args
+    if not script_args:
+        script_args = ""
+
     ssh_key = sshKeyFromName(manager, ssh_key_name)
     ssh_public_key = ssh_key.public_key
-    escaped_args = machine_config.script_args.replace('"', '\\"')
+    escaped_args = script_args.replace('"', '\\"')
     return f"""#cloud-config
 users:
   - name: {machine_config.new_user_name}

--- a/machine/config.py
+++ b/machine/config.py
@@ -1,5 +1,3 @@
-
-
 import os
 from pathlib import Path
 from machine.di import d
@@ -30,8 +28,15 @@ def _load_config_data(config_file_name: str):
 def get(config_file_name: str) -> Config:
     config = _load_config_data(config_file_name)
     config_do = config["digital-ocean"]
-    return Config(config_do["access-token"], config_do["ssh-key"], config_do.get("dns-zone"), config_do["machine-size"],
-                  config_do["image"], config_do["region"], config_do["project"])
+    return Config(
+        config_do["access-token"],
+        config_do["ssh-key"],
+        config_do.get("dns-zone"),
+        config_do["machine-size"],
+        config_do["image"],
+        config_do["region"],
+        config_do["project"],
+    )
 
 
 def get_machine(name: str) -> MachineConfig:

--- a/machine/config.py
+++ b/machine/config.py
@@ -30,7 +30,7 @@ def _load_config_data(config_file_name: str):
 def get(config_file_name: str) -> Config:
     config = _load_config_data(config_file_name)
     config_do = config["digital-ocean"]
-    return Config(config_do["access-token"], config_do["ssh-key"], config_do["dns-zone"], config_do["machine-size"],
+    return Config(config_do["access-token"], config_do["ssh-key"], config_do.get("dns-zone"), config_do["machine-size"],
                   config_do["image"], config_do["region"], config_do["project"])
 
 

--- a/machine/constants.py
+++ b/machine/constants.py
@@ -1,2 +1,1 @@
-
 default_config_file_path = "~/.machine/config.yml"

--- a/machine/defaults.py
+++ b/machine/defaults.py
@@ -1,3 +1,2 @@
-
 region = ""
 memory = ""

--- a/machine/di.py
+++ b/machine/di.py
@@ -1,4 +1,3 @@
-
 # Exposing the truth that dependency injection is just a fancy name for global variables
 
 from machine.types import CliOptions

--- a/machine/factory.py
+++ b/machine/factory.py
@@ -1,4 +1,3 @@
-
 import ruamel.yaml
 
 

--- a/machine/log.py
+++ b/machine/log.py
@@ -1,4 +1,3 @@
-
 import sys
 
 

--- a/machine/main.py
+++ b/machine/main.py
@@ -1,4 +1,3 @@
-
 import click
 from machine import config
 from machine import constants
@@ -6,7 +5,7 @@ from machine.di import d
 from machine.types import CliOptions, MainCmdCtx
 from machine.subcommands import create, destroy, list, projects, ssh_keys, domains, list_domain
 
-CLICK_CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+CLICK_CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 @click.group(context_settings=CLICK_CONTEXT_SETTINGS)

--- a/machine/subcommands/create.py
+++ b/machine/subcommands/create.py
@@ -43,9 +43,6 @@ def command(context, name, tag, type, region, machine_size, image, wait_for_ip, 
     if update_dns and not config.dns_zone:
         fatal_error("Error: DNS update requested but no zone configured")
 
-    fqdn = name
-    if config.dns_zone:
-        fqdn = f"{name}.{config.dns_zone}"
 
     manager = digitalocean.Manager(token=command_context.config.access_token)
 
@@ -55,6 +52,7 @@ def command(context, name, tag, type, region, machine_size, image, wait_for_ip, 
         machine_config = get_machine(type)
         if not machine_config:
             fatal_error(f"Error: machine type {type} is not defined")
+        fqdn = f"{name}.{config.dns_zone}" if config.dns_zone else None
         user_data = get_user_data(manager, config.ssh_key, fqdn, machine_config)
         if d.opt.debug:
             info("user-data is:")

--- a/machine/subcommands/create.py
+++ b/machine/subcommands/create.py
@@ -43,6 +43,10 @@ def command(context, name, tag, type, region, machine_size, image, wait_for_ip, 
     if update_dns and not config.dns_zone:
         fatal_error("Error: DNS update requested but no zone configured")
 
+    fqdn = name
+    if config.dns_zone:
+        fqdn = f"{name}.{config.dns_zone}"
+
     manager = digitalocean.Manager(token=command_context.config.access_token)
 
     if initialize:
@@ -51,7 +55,7 @@ def command(context, name, tag, type, region, machine_size, image, wait_for_ip, 
         machine_config = get_machine(type)
         if not machine_config:
             fatal_error(f"Error: machine type {type} is not defined")
-        user_data = get_user_data(manager, config.ssh_key, machine_config)
+        user_data = get_user_data(manager, config.ssh_key, fqdn, machine_config)
         if d.opt.debug:
             info("user-data is:")
             info(user_data)

--- a/machine/subcommands/destroy.py
+++ b/machine/subcommands/destroy.py
@@ -1,46 +1,59 @@
-
 import click
 import digitalocean
+
 from machine.di import d
 from machine.log import debug, fatal_error
-from machine.util import dnsRecordIdFromName
+from machine.util import dnsRecordIdFromName, is_machine_created
 from machine.types import MainCmdCtx
 
 
-@click.command(help="Destroy a machine")
-@click.option('--confirm/--no-confirm', default=True)
-@click.option('--delete-dns/--no-delete-dns', default=True)
-@click.argument('droplet-id')
+@click.command(help="Destroy one or more machines")
+@click.option("--confirm/--no-confirm", default=True)
+@click.option("--delete-dns/--no-delete-dns", default=True)
+@click.option(
+    "--include-unmanaged",
+    is_flag=True,
+    default=False,
+    help="Include machines not created by this tool",
+)
+@click.argument("droplet-ids", nargs=-1)
 @click.pass_context
-def command(context, confirm, delete_dns, droplet_id):
+def command(context, confirm, delete_dns, include_unmanaged, droplet_ids):
     command_context: MainCmdCtx = context.obj
     config = command_context.config
     manager = digitalocean.Manager(token=config.access_token)
-    try:
-        droplet = manager.get_droplet(droplet_id)
-    except digitalocean.NotFoundError:
-        fatal_error(f"Error: machine with id {droplet_id} not found")
-    name = droplet.name
-    if confirm:
-        print("Type YES (not y or yes or Yes) to confirm that you want to permanently"
-              f" DELETE/DESTROY droplet \"{name}\" (id: {droplet.id})")
-        confirmation = input()
-        if confirmation != "YES":
-            fatal_error("Destroy operation aborted, not confirmed by user")
-    result = droplet.destroy()
+    for droplet_id in droplet_ids:
+        try:
+            droplet = manager.get_droplet(droplet_id)
+        except digitalocean.NotFoundError:
+            fatal_error(f"Error: machine with id {droplet_id} not found")
+        name = droplet.name
 
-    if result and delete_dns and config.dns_zone:
-        zone = config.dns_zone
-        host = name
-        if d.opt.debug:
-            debug(f"Deleting host record {host}.{zone}")
-        domain = digitalocean.Domain(token=config.access_token, name=zone)
-        if not domain:
-            fatal_error(f"Error: Domain {domain} does not exist, machine destroyed but DNS record not removed")
-        record_id = dnsRecordIdFromName(domain, name)
-        if d.opt.debug:
-            debug(f"Deleting dns record id={record_id}")
-        domain.delete_domain_record(id=record_id)
+        if not is_machine_created(droplet) and not include_unmanaged:
+            fatal_error(f'ERROR: Cannot destroy droplet "{name}" (id: {droplet.id}), it was not created by machine.')
 
-    if not result:
-        fatal_error("Error destroying machine")
+        if confirm:
+            print(
+                "Type YES (not y or yes or Yes) to confirm that you want to permanently"
+                f' DELETE/DESTROY droplet "{name}" (id: {droplet.id})'
+            )
+            confirmation = input()
+            if confirmation != "YES":
+                fatal_error("Destroy operation aborted, not confirmed by user")
+        result = droplet.destroy()
+
+        if result and delete_dns and config.dns_zone:
+            zone = config.dns_zone
+            host = name
+            if d.opt.debug:
+                debug(f"Deleting host record {host}.{zone}")
+            domain = digitalocean.Domain(token=config.access_token, name=zone)
+            if not domain:
+                fatal_error(f"Error: Domain {domain} does not exist, machine destroyed but DNS record not removed")
+            record_id = dnsRecordIdFromName(domain, name)
+            if d.opt.debug:
+                debug(f"Deleting dns record id={record_id}")
+            domain.delete_domain_record(id=record_id)
+
+        if not result:
+            fatal_error("Error destroying machine")

--- a/machine/subcommands/domains.py
+++ b/machine/subcommands/domains.py
@@ -1,4 +1,3 @@
-
 import click
 import digitalocean
 from machine.log import output

--- a/machine/subcommands/list.py
+++ b/machine/subcommands/list.py
@@ -1,14 +1,100 @@
-
 import click
+import json
 import digitalocean
-from machine.types import MainCmdCtx
+
+from machine.log import fatal_error
+from machine.types import MainCmdCtx, TAG_MACHINE_TYPE_PREFIX
+from machine.util import get_machine_type, is_machine_created
+
+
+def print_normal(droplets):
+    for droplet in droplets:
+        print(f"{droplet.name} ({droplet.id}, {droplet.region['slug']}, {get_machine_type(droplet)}): {droplet.ip_address}")
+
+
+def print_quiet(droplets):
+    for droplet in droplets:
+        print(droplet.id)
+
+
+def print_json(droplets):
+    simplified = []
+    for d in droplets:
+        simple = {
+            "id": d.id,
+            "name": d.name,
+            "tags": d.tags,
+            "region": d.region["slug"],
+            "ip": d.ip_address,
+            "type": get_machine_type(d),
+        }
+        simplified.append(simple)
+    print(json.dumps(simplified))
 
 
 @click.command(help="List machines")
+@click.option("--id", metavar="<MACHINE-ID>", help="Filter by id")
+@click.option("--name", "-n", metavar="<MACHINE-NAME>", help="Filter by name")
+@click.option("--tag", "-t", metavar="<TAG-TEXT>", help="Filter by tag")
+@click.option("--type", "-m", metavar="<MACHINE-TYPE>", help="Filter by type")
+@click.option("--region", "-r", metavar="<REGION>", help="Filter by region")
+@click.option("--output", "-o", metavar="<FORMAT>", help="Output format")
+@click.option(
+    "--include-unmanaged",
+    is_flag=True,
+    default=False,
+    help="Include machines not created by this tool",
+)
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Only display machine IDs")
+@click.option(
+    "--unique",
+    is_flag=True,
+    default=False,
+    help="Return an error if there is more than one match",
+)
 @click.pass_context
-def command(context):
+def command(context, id, name, tag, type, region, include_unmanaged, output, quiet, unique):
     command_context: MainCmdCtx = context.obj
     manager = digitalocean.Manager(token=command_context.config.access_token)
-    droplets = manager.get_all_droplets()
-    for droplet in droplets:
-        print(f"{droplet.name} ({droplet.id}, {droplet.region['slug']}): {droplet.ip_address}")
+
+    droplets = []
+    if id:
+        droplet = manager.get_droplet(id)
+        if droplet:
+            droplets.append(droplet)
+    elif name:
+        droplets = manager.get_all_droplets(params={"name": name})
+    elif tag:
+        droplets = manager.get_all_droplets(tag_name=tag)
+    elif type:
+        droplets = manager.get_all_droplets(tag_name=TAG_MACHINE_TYPE_PREFIX + type.lower())
+    else:
+        droplets = manager.get_all_droplets()
+
+    # we can't combine most filters over the API, so we also filter ourselves
+    if name:
+        droplets = filter(lambda d: d.name == name, droplets)
+
+    if tag:
+        droplets = filter(lambda d: tag in d.tags, droplets)
+
+    if type:
+        droplets = filter(lambda d: TAG_MACHINE_TYPE_PREFIX + type.lower() in d.tags, droplets)
+
+    if region:
+        droplets = filter(lambda d: region == d.region["slug"], droplets)
+
+    if not include_unmanaged:
+        droplets = filter(lambda d: is_machine_created(d), droplets)
+
+    droplets = list(droplets)
+
+    if unique and len(droplets) > 1:
+        fatal_error(f"ERROR: --unique match required but {len(droplets)} matches found.")
+
+    if output == "json":
+        print_json(droplets)
+    elif quiet:
+        print_quiet(droplets)
+    else:
+        print_normal(droplets)

--- a/machine/subcommands/list_domain.py
+++ b/machine/subcommands/list_domain.py
@@ -34,7 +34,7 @@ def print_json(records, droplets, zone):
 
 @click.command(help="List domain records")
 @click.option("--name", "-n", metavar="<RECORD-NAME>", help="Filter by name")
-@click.option("--type", "-m", metavar="<RECORD-TYPE>", help="Filter by type (default A and AAA)")
+@click.option("--type", "-m", metavar="<RECORD-TYPE>", help="Filter by type (default A and AAAA)")
 @click.option("--output", "-o", metavar="<FORMAT>", help="Output format")
 @click.option("--quiet", "-q", is_flag=True, default=False, help="Only display machine IDs")
 @click.option(
@@ -58,7 +58,7 @@ def command(context, name, type, output, quiet, include_unmanaged, zone):
         if type != "*":
             records = filter(lambda r: r.type == type, records)
     else:
-        records = filter(lambda r: r.type in ["A", "AAA", "AAAA"], records)
+        records = filter(lambda r: r.type in ["A", "AAAA"], records)
 
     droplets = []
     if not include_unmanaged:

--- a/machine/subcommands/list_domain.py
+++ b/machine/subcommands/list_domain.py
@@ -1,16 +1,76 @@
-
 import click
 import digitalocean
-from machine.types import MainCmdCtx
+import json
+
+from machine.log import fatal_error
+from machine.types import MainCmdCtx, TAG_MACHINE_CREATED
+
+
+def print_normal(records, zone):
+    for record in records:
+        print(f"{record.name}\t{record.type}\t{record.data}")
+
+
+def print_quiet(records):
+    for record in records:
+        print(record.name)
+
+
+def print_json(records, droplets, zone):
+    simplified = []
+    for r in records:
+        droplet_id = next((d.id for d in droplets if r.data == d.ip_address), None)
+        simple = {
+            "id": r.id,
+            "droplet": droplet_id,
+            "name": r.name,
+            "data": r.data,
+            "ttl": r.ttl,
+            "type": r.type,
+        }
+        simplified.append(simple)
+    print(json.dumps(simplified))
 
 
 @click.command(help="List domain records")
-@click.argument('zone')
+@click.option("--name", "-n", metavar="<RECORD-NAME>", help="Filter by name")
+@click.option("--type", "-m", metavar="<RECORD-TYPE>", help="Filter by type (default A and AAA)")
+@click.option("--output", "-o", metavar="<FORMAT>", help="Output format")
+@click.option("--quiet", "-q", is_flag=True, default=False, help="Only display machine IDs")
+@click.option(
+    "--include-unmanaged",
+    is_flag=True,
+    default=False,
+    help="Include records not created by this tool",
+)
+@click.argument("zone", required=False)
 @click.pass_context
-def command(context, zone):
+def command(context, name, type, output, quiet, include_unmanaged, zone):
     command_context: MainCmdCtx = context.obj
+    if not zone:
+        zone = command_context.config.dns_zone
+    if not zone:
+        fatal_error("Error: no DNS zone specified.")
     domain = digitalocean.Domain(token=command_context.config.access_token, name=zone)
     records = domain.get_records()
-    for record in records:
-        if record.type == "A" or record.type == "AAA":
-            print(f"{record.name}")
+
+    if type:
+        if type != "*":
+            records = filter(lambda r: r.type == type, records)
+    else:
+        records = filter(lambda r: r.type in ["A", "AAA", "AAAA"], records)
+
+    droplets = []
+    if not include_unmanaged:
+        manager = digitalocean.Manager(token=command_context.config.access_token)
+        droplets = manager.get_all_droplets(tag_name=TAG_MACHINE_CREATED)
+        droplet_ips = [d.ip_address for d in droplets]
+        records = filter(lambda r: r.data in droplet_ips, records)
+
+    records = list(records)
+    if output == "json":
+        print_json(records, droplets, zone)
+    elif quiet:
+        print_quiet(records)
+    else:
+        print_normal(records, zone)

--- a/machine/subcommands/projects.py
+++ b/machine/subcommands/projects.py
@@ -1,4 +1,3 @@
-
 import click
 import digitalocean
 from machine.log import output

--- a/machine/subcommands/ssh_keys.py
+++ b/machine/subcommands/ssh_keys.py
@@ -1,4 +1,3 @@
-
 import click
 import digitalocean
 from machine.log import output

--- a/machine/types.py
+++ b/machine/types.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
 
+TAG_MACHINE_CREATED = "machine:created"
+TAG_MACHINE_TYPE_PREFIX = "machine:type:"
+
 
 @dataclass
 class CliOptions:

--- a/machine/util.py
+++ b/machine/util.py
@@ -1,5 +1,5 @@
-
 from digitalocean import Domain, Manager, Project, SSHKey
+from machine.types import TAG_MACHINE_TYPE_PREFIX, TAG_MACHINE_CREATED
 
 
 def projectFromName(manager: Manager, name: str) -> Project:
@@ -24,3 +24,14 @@ def dnsRecordIdFromName(domain: Domain, name: str) -> str:
         if record.name == name:
             return record.id
     return None
+
+
+def get_machine_type(droplet):
+    type = next((t for t in droplet.tags if TAG_MACHINE_TYPE_PREFIX in t), "").replace(TAG_MACHINE_TYPE_PREFIX, "")
+    if not type:
+        return None
+    return type
+
+
+def is_machine_created(droplet):
+    return TAG_MACHINE_CREATED in droplet.tags

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ click==8.1.7
 python-digitalocean==1.17.0
 ruamel.yaml==0.17.32
 ruamel.yaml.clib==0.2.7
+flake8
+black

--- a/sh/lint.sh
+++ b/sh/lint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ "$1" == "--fix" ]]; then
+  LINE_LENGTH=$(cat tox.ini | grep 'max-line-length' | cut -d'=' -f2 | awk '{ print $1 }')
+  black -l ${LINE_LENGTH:-132} machine/ 
+fi
+
+flake8 --config tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,4 @@ extend-ignore = E203
 exclude = .git,__pycache__,old,build,dist,dev
 max-complexity = 25
 max-line-length = 132
+per-file-ignores = ./machine/cloud_config.py:E501


### PR DESCRIPTION
```
❯ machine list --help
Usage: machine list [OPTIONS]

  List machines

Options:
  --id <MACHINE-ID>          Filter by id
  -n, --name <MACHINE-NAME>  Filter by name
  -t, --tag <TAG-TEXT>       Filter by tag
  -m, --type <MACHINE-TYPE>  Filter by type
  -r, --region <REGION>      Filter by region
  -o, --output <FORMAT>      Output format
  --include-unmanaged        Include machines not created by this tool
  -q, --quiet                Only display machine IDs
  --unique                   Return an error if there is more than one match
  -h, --help                 Show this message and exit.
```


```
Usage: machine list-domain [OPTIONS] [ZONE]

  List domain records

Options:
  -n, --name <RECORD-NAME>  Filter by name
  -m, --type <RECORD-TYPE>  Filter by type (default A and AAAA)
  -o, --output <FORMAT>     Output format
  -q, --quiet               Only display machine IDs
  --include-unmanaged       Include records not created by this tool
  -h, --help                Show this message and exit.
```

```
❯ machine destroy --help
Usage: machine destroy [OPTIONS] [DROPLET_IDS]...

  Destroy one or more machines

Options:
  --confirm / --no-confirm
  --delete-dns / --no-delete-dns
  --include-unmanaged             Include machines not created by this tool
  -h, --help                      Show this message and exit.
````