### PR TITLE
Make script-url and optional part of the machine definition.

### DIFF
--- a/machine/config.py
+++ b/machine/config.py
@@ -47,8 +47,8 @@ def get_machine(name: str) -> MachineConfig:
     target_config = config_machines[name]
     return MachineConfig(
         target_config["new-user-name"],
-        target_config["script-url"],
-        target_config["script-dir"],
-        target_config["script-path"],
-        target_config["script-args"],
+        target_config.get("script-url"),
+        target_config.get("script-dir"),
+        target_config.get("script-path"),
+        target_config.get("script-args"),
     )


### PR DESCRIPTION
This allows for simpler machine definitions like:

```
machines:
    basic:
        new-user-name: foo
```