### PR TITLE
Update Vultr image ID in end-to-end tests

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -47,7 +47,7 @@ _PROVIDER_DEFAULTS = {
     },
     "vultr": {
         "region": "ewr",
-        "image": "2136",
+        "image": "2284",
         "size": "vc2-1c-1gb",
     },
 }


### PR DESCRIPTION
Claude previously selected an image id that corresponds to Debian. This changes that to Ubuntu 24.04.
Current list of ids:

```
$ ~/go/bin/vultr-cli os list | grep ubuntu
1743    Ubuntu 22.04 LTS x64                    x64     ubuntu
2284    Ubuntu 24.04 LTS x64                    x64     ubuntu
2657    Ubuntu 25.10 x64                        x64     ubuntu
```

Fixes https://github.com/stirlingbridge/machine/issues/58