### PR TITLE
Fixes for various Vultr API issues

### DIFF
--- a/machine/providers/vultr.py
+++ b/machine/providers/vultr.py
@@ -1,4 +1,5 @@
 import base64
+import time
 
 from vultr import Vultr, VultrException
 
@@ -64,11 +65,23 @@ class VultrProvider(CloudProvider):
         return _instance_to_vm(result)
 
     def destroy_vm(self, vm_id) -> bool:
-        try:
-            self._client.delete_instance(vm_id)
-        except VultrException as e:
-            fatal_error(f"Error: machine with id {vm_id} not found: {e}")
-        return True
+        # Vultr returns HTTP 500 if the instance is still pending or locked
+        # (e.g. during provisioning). Retry deletion with backoff.
+        for attempt in range(24):
+            try:
+                self._client.delete_instance(vm_id)
+                return True
+            except VultrException as e:
+                error_msg = str(e)
+                if "500" in error_msg and ("not currently active" in error_msg or "currently locked" in error_msg):
+                    info("Waiting for instance to become ready before destroying...")
+                    time.sleep(5)
+                elif "404" in error_msg:
+                    return True  # already gone
+                else:
+                    fatal_error(f"Error: machine with id {vm_id} not found: {e}")
+        fatal_error(f"Error: timed out waiting to destroy instance {vm_id}")
+        return False
 
     def list_vms(self, tag=None) -> list:
         try:

--- a/machine/subcommands/create.py
+++ b/machine/subcommands/create.py
@@ -83,12 +83,14 @@ def command(context, name, tag, type, region, machine_size, image, wait_for_ip, 
             info(f"Assigned droplet to project: {config.project}")
 
     # If requested, or if we are going to set a DNS record get the VM's IPv4 address
-    ip_address = vm.ip_address
+    # Vultr returns "0.0.0.0" as main_ip while the instance is still pending,
+    # so treat that the same as no IP assigned yet.
+    ip_address = vm.ip_address if vm.ip_address != "0.0.0.0" else None
     if (wait_for_ip or update_dns) and not ip_address:
         while not ip_address:
             time.sleep(1)
             vm = provider.get_vm(vm.id)
-            ip_address = vm.ip_address
+            ip_address = vm.ip_address if vm.ip_address != "0.0.0.0" else None
             if d.opt.verbose:
                 output("Waiting for droplet IP address")
         if d.opt.quiet:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -235,7 +235,7 @@ def instance(config_file, session_id):
     yield info
 
     # ---- TEARDOWN: destroy with DNS cleanup --------------------------------
-    run_machine(
+    destroy_result = run_machine(
         "--verbose",
         "destroy",
         "--no-confirm",
@@ -244,6 +244,10 @@ def instance(config_file, session_id):
         config_file=config_file,
         session_id=session_id,
     )
+    if destroy_result.returncode != 0:
+        print(f"TEARDOWN WARNING: destroy exited {destroy_result.returncode}", flush=True)
+        print(f"  stdout: {destroy_result.stdout}", flush=True)
+        print(f"  stderr: {destroy_result.stderr}", flush=True)
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +292,9 @@ class TestInstanceLifecycle:
         instances = json.loads(result.stdout)
         matched = [i for i in instances if str(i["id"]) == instance["id"]]
         assert len(matched) == 1
-        assert matched[0]["ip"] is not None, "Instance has no IP address"
+        ip = matched[0]["ip"]
+        assert ip is not None, "Instance has no IP address"
+        assert ip != "0.0.0.0", "Instance IP is 0.0.0.0 (not yet assigned)"
 
     def test_dns_record_created(self, instance, config_file, session_id):
         """Verify that a DNS A record was created for the instance."""


### PR DESCRIPTION
## Summary

Fixes four open Vultr issues (#53, #55, #57, #61) which all stem from two Vultr-specific API behaviors that differ from DigitalOcean:

1. **Vultr returns `0.0.0.0` as the initial IP** for pending instances (DO returns empty/null). The `create` command treated `"0.0.0.0"` as a valid IP, skipping the wait-for-IP loop entirely. This caused DNS records to be created with `0.0.0.0`.

2. **Vultr rejects deletion of pending/locked instances** with HTTP 500 (DO allows deleting in any state). Because the IP wait was skipped, the create command returned in ~2 seconds, and the test teardown tried to destroy the VM while it was still provisioning — silently failing every time.

## Changes

- **`machine/subcommands/create.py`**: Treat `"0.0.0.0"` the same as `None` when checking the IP address, so the wait-for-IP loop runs correctly on Vultr.

- **`machine/providers/vultr.py`**: Retry `destroy_vm` with 5s backoff (up to 2 min) when Vultr returns transient 500 errors ("not currently active" or "currently locked").

- **`tests/test_e2e.py`**: Strengthen `test_instance_has_ip` to reject `0.0.0.0`. Add teardown diagnostics so future destroy failures are visible in test output.

## Test plan

- [x] All 6 Vultr e2e tests pass (previously `test_dns_record_created` always failed)
- [x] VM is fully cleaned up after test run (previously accumulated on every run)
- [x] All 29 unit tests pass
- [x] `ruff check` passes

Closes #53, closes #55, closes #57, closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)