### PR TITLE
Handle provider auth failures gracefully (#95)

### DIFF
--- a/machine/main.py
+++ b/machine/main.py
@@ -5,7 +5,7 @@ import click
 from machine import config
 from machine import constants
 from machine.di import d
-from machine.log import output
+from machine.log import fatal_error, output
 from machine.providers import create_provider
 from machine.subcommands import check, create, destroy, info, list, projects, ssh_keys, domains, list_domain, types, status
 from machine.types import CliOptions, MainCmdCtx
@@ -60,3 +60,63 @@ main.add_command(projects.command, "projects")
 main.add_command(ssh_keys.command, "ssh-keys")
 main.add_command(types.command, "types")
 main.add_command(status.command, "status")
+
+
+def _provider_api_exception_types():
+    """Base exception classes raised by the cloud provider SDKs on API failures.
+
+    Collected lazily so importing this module (and the common DigitalOcean path)
+    does not pull in every provider SDK up front.
+    """
+    import digitalocean
+    from vultr import VultrException
+
+    types = [digitalocean.Error, VultrException]
+    try:
+        from google.api_core import exceptions as google_api_exceptions
+        from google.auth import exceptions as google_auth_exceptions
+
+        types.append(google_api_exceptions.GoogleAPICallError)
+        types.append(google_auth_exceptions.GoogleAuthError)
+    except ImportError:
+        pass
+    return tuple(types)
+
+
+def _friendly_provider_error(e) -> str:
+    """Turn a raw provider SDK exception into a clear, actionable message."""
+    detail = str(e).strip()
+    lowered = detail.lower()
+    auth_markers = (
+        "unable to authenticate",
+        "authentication",
+        "unauthenticated",
+        "unauthorized",
+        "invalid api key",
+        "permission",
+        "forbidden",
+        "401",
+        "403",
+    )
+    if any(marker in lowered for marker in auth_markers):
+        return (
+            "Error: the cloud provider rejected the request as unauthenticated or unauthorized.\n"
+            "Check that the API token/key in your config file is correct and has not expired."
+        )
+    return f"Error: cloud provider request failed: {detail}"
+
+
+def cli():
+    """Console-script entry point.
+
+    Wraps the Click group so that errors raised by a provider's API (for
+    example an expired or invalid access token) are reported as a clear
+    message instead of an uncaught Python traceback (#95). Pass --debug to
+    see the underlying traceback.
+    """
+    try:
+        main()
+    except _provider_api_exception_types() as e:
+        if d.opt is not None and d.opt.debug:
+            raise
+        fatal_error(_friendly_provider_error(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.scripts]
-machine = "machine.main:main"
+machine = "machine.main:cli"
 
 [project.urls]
 Homepage = "https://github.com/stirlingbridge/machine"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,64 @@
+"""Tests for graceful handling of cloud provider API errors (#95).
+
+These are hermetic: instead of making real API calls they drive the
+``cli`` entry-point wrapper directly, forcing the underlying Click group to
+raise the same exceptions a provider SDK would raise on an auth failure.
+"""
+
+import digitalocean
+import pytest
+
+from machine import main as main_module
+from machine.types import CliOptions
+
+
+@pytest.fixture(autouse=True)
+def reset_options():
+    """Ensure the global CLI options don't leak between tests."""
+    saved = main_module.d.opt
+    main_module.d.opt = None
+    yield
+    main_module.d.opt = saved
+
+
+class TestFriendlyProviderError:
+    def test_auth_failure_message_is_actionable(self):
+        msg = main_module._friendly_provider_error(digitalocean.DataReadError("Unable to authenticate you"))
+        assert "unauthenticated or unauthorized" in msg
+        assert "config file" in msg
+        # The scary raw exception text should not leak into the friendly message.
+        assert "DataReadError" not in msg
+
+    def test_non_auth_failure_includes_detail(self):
+        msg = main_module._friendly_provider_error(digitalocean.DataReadError("Rate limit exceeded"))
+        assert "Rate limit exceeded" in msg
+        assert "cloud provider request failed" in msg
+
+
+class TestCliWrapper:
+    def _run_cli(self, monkeypatch, exc):
+        def boom():
+            raise exc
+
+        monkeypatch.setattr(main_module, "main", boom)
+        return main_module.cli
+
+    def test_auth_error_produces_message_not_traceback(self, monkeypatch, capsys):
+        run = self._run_cli(monkeypatch, digitalocean.DataReadError("Unable to authenticate you"))
+        with pytest.raises(SystemExit) as exc_info:
+            run()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "unauthenticated or unauthorized" in err
+        assert "Traceback" not in err
+
+    def test_debug_flag_reraises_original_exception(self, monkeypatch):
+        main_module.d.opt = CliOptions(debug=True, quiet=False, verbose=False, dry_run=False)
+        run = self._run_cli(monkeypatch, digitalocean.DataReadError("Unable to authenticate you"))
+        with pytest.raises(digitalocean.DataReadError):
+            run()
+
+    def test_non_provider_exception_is_not_swallowed(self, monkeypatch):
+        run = self._run_cli(monkeypatch, ValueError("some internal bug"))
+        with pytest.raises(ValueError):
+            run()


### PR DESCRIPTION
## Problem
An invalid/expired provider API token caused an uncaught `digitalocean.DataReadError` to bubble up as a raw Python traceback (#95). The DigitalOcean provider only wrapped a few calls (`create_vm`, `destroy_vm`), so read paths like `list_vms` → `get_all_droplets` crashed ungracefully.

## Fix
Added a top-level entry-point wrapper `cli()` in `machine/main.py` that runs the Click group and catches the provider SDKs' base API exceptions, converting them into a clear message instead of a traceback:

- Catches `digitalocean.Error`, `vultr.VultrException`, and (lazily) the Google Cloud auth/API exception bases — so it's a safety net across **all** subcommands and providers, not just `list`.
- Auth-style failures (401/403/"unable to authenticate"/permission) get an actionable message pointing at the config token; other API errors report the underlying detail.
- `--debug` re-raises the original exception so the full traceback is still available for troubleshooting.
- Non-provider exceptions (real bugs) are **not** swallowed — they still surface.

Updated `[project.scripts]` in `pyproject.toml` to point `machine` at `machine.main:cli` (the shiv build uses this console script automatically).

Now:
```
$ machine --config-file … list
Error: the cloud provider rejected the request as unauthenticated or unauthorized.
Check that the API token/key in your config file is correct and has not expired.
```

## Verification
- Reproduced the original traceback, then confirmed the graceful message (exit 1) after the fix, and that `--debug` still shows the traceback.
- Confirmed normal commands (`version`, `types`), Click usage errors, and help are unaffected.
- Added hermetic tests in `tests/test_error_handling.py` (message formatting, wrapper catches provider errors, `--debug` re-raises, non-provider exceptions pass through).
- Full suite: **52 passed**, lint clean.

[Claude session](https://codeassociates.github.io/conversations-with-claude/conversations/python-cli-tool/improve-auth-failure-handling/index.html)